### PR TITLE
修复在某些手机上进度无法到达100%的问题

### DIFF
--- a/videoprocessor/src/main/java/com/hw/videoprocessor/VideoEncodeThread.java
+++ b/videoprocessor/src/main/java/com/hw/videoprocessor/VideoEncodeThread.java
@@ -134,9 +134,9 @@ public class VideoEncodeThread extends Thread implements IVideoEncodeThread {
             CL.i("encode outputBufferIndex = " + outputBufferIndex);
             if (signalEncodeEnd && outputBufferIndex == MediaCodec.INFO_TRY_AGAIN_LATER) {
                 encodeTryAgainCount++;
-                if (encodeTryAgainCount > 10) {
+                if (encodeTryAgainCount > 20) {
                     //三星S8上出现signalEndOfInputStream之后一直tryAgain的问题
-                    CL.e("INFO_TRY_AGAIN_LATER 10 times,force End!");
+                    CL.e("INFO_TRY_AGAIN_LATER 20 times,force End!");
                     break;
                 }
             } else {


### PR DESCRIPTION
这个问题在一台android6.0的vivo手机上复现了，一个14秒的视频，压缩进度会卡在97%，通过修改重试此时可以解决。经过测试压缩1分钟的视频也无问题。虽然可能不是治本的办法，但是增加了压缩的成功率。